### PR TITLE
Add Package Command and Project Specific Ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
+.idea/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ channel. Uncheck this box for faster deployment, provided the Roku does not cras
 `Automatically discover Rokus on the local network` - if checked, will automatically attempt to discover all Rokus on the local network.
 If un-checked, will disable automatic discovery, only allowing Roku devices to be manually entered.
 
+#### .rokudevignore
+
+Ignores can optionally be placed in the file `.rokudevignore`. This file should 
+reside in the same directory as the manifest file.
+
+Rules:
+
+- Lines beginning with a hash (`#`) will be ignored.
+- Lines beginning with a exclamation mark (`!`) will be treated as unignores.
+- All other lines will be treated as ignores.
+- All lines should be relative paths with the root starting at .rokudevignore's 
+  containing directory
+- Lines consisting of a file or directory name, with or without a trailing 
+  forward slash will be applied against any file or directory name in the 
+  directory hierarchy.
+- Unignores can be used to specify that a file should not be ignored. This is
+  useful when specifying a file/directory name to be ignored globally, but not
+  wanting to ignore a specific file.
+- Path separators in .rokudevignore are forward slashes.
+
 ### Keyboard shortcuts
 
 roku-develop uses two commands, ```roku-develop:toggle```

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -322,7 +322,7 @@ module.exports        = RokuDevelop =
       pass: @rokuPassword,
       sendImmediately: false
     }
-    request.get {url: url, timeout: 15000, auth: auth}, \
+    request.get {url: url, timeout: 15000, auth: auth, encoding: null}, \
         (error, response, body) =>
       if error or not response or response.statusCode != 200 or not body
         atom.notifications.addWarning 'Failed to download application package',

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -604,6 +604,7 @@ module.exports        = RokuDevelop =
       pathname = entry.getRealPathSync()
       relPath = entry.getPath()
         .replace(@projectDirectory.getRealPathSync(), '')
+        .replace(/\\/g, '/')
       if relPath.startsWith('/')
         relPath = relPath.replace('/', '')
       # Ignore hidden files and directories, and excluded files and directories

--- a/menus/roku-develop.cson
+++ b/menus/roku-develop.cson
@@ -10,6 +10,10 @@
         {
         label: 'Toggle device list'
         command: 'roku-develop:toggle'
+        },
+        {
+        label: 'Package'
+        command: 'roku-develop:package'
         }
       ]
     }
@@ -27,6 +31,10 @@ menu: [
         {
         label: 'Toggle device list'
         command: 'roku-develop:toggle'
+        },
+        {
+        label: 'Package'
+        command: "roku-develop:package"
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "activationCommands": {
     "atom-workspace": [
       "roku-develop:toggle",
-      "roku-develop:deploy"
+      "roku-develop:deploy",
+      "roku-develop:package"
     ]
   },
   "repository": "https://github.com/belltown/roku-develop",


### PR DESCRIPTION
# Package Command

This PR adds a new command `roku-develop:package`, including an entry to the roku-develop context-menu and packages menu. One settings field is also added for the Roku packaging password. Once invoked, one Roku will be contacted and prompted to package the currently installed application with the name and version derived from the current project's manifest. If the packaing is succesful, the package will be downloaded to the output directory.

Notes:

- A deploy is not trigged before packaging.
- The task is configured to fail if more than one Roku is selected when it is executed.

# .rokudevignore

This PR also includes project specific archive ignores. The ignores from the settings have not been changed. An optional file `.rokudevignore` can reside next to a project's manifest to add (un)ignores.

Rules:

- Lines beginning with a hash (`#`) will be ignored.
- Lines beginning with a exclamation mark (`!`) will be treated as unignores.
- All other lines will be treated as ignores.
- All lines should be relative paths with the root starting at .rokudevignore's 
  containing directory
- Lines consisting of a file or directory name, with or without a trailing 
  forward slash will be applied against any file or directory name in the 
  directory hierarchy.
- Unignores can be used to specify that a file should not be ignored. This is
  useful when specifying a file/directory name to be ignored globally, but not
  wanting to ignore a specific file.
- Path separators in .rokudevignore are forward slashes.

Example .rokudevignore:

```
# Ignore all files (and directories) that match this name
ignore_this.txt

# Unignore this specific file that has been ignored by the previous global ignore
!resources/ignore_this.txt

# Unignore the file only in the root directory while still applying the global ignore
!ignore_this.txt
```