### PR TITLE
Add default package serial number option

### DIFF
--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -284,7 +284,7 @@ module.exports        = RokuDevelop =
 
       packageIP = ''
       for entry in @rokuDeviceTable.getValues()
-        if entry.serialNumber == @rokuPackageSN
+        if entry.serialNumber == @rokuPackageSN and entry.deploy
           packageIP = entry.ipAddr
 
       if packageIP not in @rokuIPList

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -282,6 +282,7 @@ module.exports        = RokuDevelop =
                                        or set a default packaging device.', {dismissable: true}
         return
 
+      packageIP = ''
       for entry in @rokuDeviceTable.getValues()
         if entry.serialNumber == @rokuPackageSN
           packageIP = entry.ipAddr

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -275,13 +275,16 @@ module.exports        = RokuDevelop =
                                     }
       return
 
-    # Check that only one discovered device is selected
+    # Check whether the default packaging device is set and included in the device
+    # list, if more than one device is enabled
     if @rokuIPList.length != 1
       if not @rokuPackageSN?.length
         atom.notifications.addWarning 'Either select only a single device,
                                        or set a default packaging device.', {dismissable: true}
         return
 
+      # Search through the serial numbers in the device table for one that matches
+      # the default set by the user, and get the corresponding IP address
       packageIP = ''
       for entry in @rokuDeviceTable.getValues()
         if entry.serialNumber == @rokuPackageSN and entry.deploy
@@ -304,6 +307,8 @@ module.exports        = RokuDevelop =
           {dismissable: true, detail: error.message}
         return
       # Send the package post request
+      # If more than one device is selected use the user-set default;
+      # otherwise, if only one is selected, use that device
       if @rokuIPList.length != 1
         ip = packageIP
       else


### PR DESCRIPTION
When developing with multiple devices I find it a little annoying to have to uncheck and recheck all the devices but one every time I package an application, especially because I consistently use a particular box for packaging.

This adds the option to set a default device for packaging (by ~~IP~~ serial number). If a default ~~IP~~ SN is set, and the device corresponding to that ~~IP~~ SN is in the device list and enabled, it will be used for packaging even if other devices are also enabled for deployment. Otherwise (if a default is not set, or the default device is unchecked), packaging should work as before—uncheck all the boxes but one to use that device.

I have basically never used coffeescript before so this code may not be great, and there could be issues I haven't noticed, but it seems to work OK for me so far.