### PR TITLE
Add a shortcut to switch between brs/xml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Thanks for your efforts, Mike.
 
 Thanks to [AhmedGamal-Inmobly](https://github.com/AhmedGamal-Inmobly),
 [Rolando Islas](https://github.com/rolandoislas),
-and [michael](https://github.com/entrez) for their contributions to this package.
+and [Michael Meyer](https://github.com/entrez) for their contributions to this package.
 
 Another useful package for Roku development is
 [language-brightscript](https://atom.io/packages/language-brightscript),

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ In addition, the following keyboard shortcuts are defined by default:
 
 <kbd>Alt+;</kbd> (Alt-semicolon) - Package the currently-deployed application.
 
+<kbd>Ctrl-Alt+X</kbd> (Ctrl-Alt-x) - Switch between the current component's brs and xml files, if applicable.
+
 If you find that these particular key combinations don't work well with
 your keyboard configuration, you can change them:
 
@@ -91,8 +93,8 @@ under Keybindings.
 
 2. Edit your Atom keymap.cson file
 (look under **File > Keymap...** or **Edit > Keymap...**),
-then add your own keybindings. For example, to use <kbd>Ctrl+7</kbd>, <kbd>Ctrl+8</kbd> and
-<kbd>Ctrl+9</kbd> instead, place the following lines at the end of
+then add your own keybindings. For example, to use <kbd>Ctrl+7</kbd>, <kbd>Ctrl+8</kbd>,
+<kbd>Ctrl+9</kbd> and <kbd>Ctrl+0</kbd> instead, place the following lines at the end of
 your keymap.cson file:
 
 ```
@@ -100,6 +102,7 @@ your keymap.cson file:
   'ctrl-7': 'roku-develop:package'
   'ctrl-8': 'roku-develop:toggle'
   'ctrl-9': 'roku-develop:deploy'
+  'ctrl-0': 'roku-develop:switch-files'
 ```
 
 ### Usage
@@ -129,6 +132,13 @@ Uncheck the boxes for devices not to be deployed to.**
 - If a Default Packaging Device is specified in the Config Settings, it will be used, unless one and only one device is checked.
 - Package must first be deployed to the Roku before it can be packaged.
 - Package will be written to the same directory as the Zip File Directory specified in Settings.
+
+---
+
+<kbd>Ctrl-Alt+X</kbd> (Ctrl-Alt-x) - Switch between the current component's script (\*.brs) and layout (\*.xml) files.
+- If the corresponding file is already open in another tab and/or pane, focus will move to that tab/pane.
+- If the file is not open yet, a new tab containing it will be opened under the current active pane.
+- If no corresponding file exists (i.e. the current directory contains only a .brs or only an .xml file), no action will be taken.
 
 ---
 

--- a/keymaps/roku-develop.cson
+++ b/keymaps/roku-develop.cson
@@ -2,3 +2,4 @@
   'ctrl-;': 'roku-develop:toggle'
   'ctrl-alt-;': 'roku-develop:deploy'
   'alt-;': 'roku-develop:package'
+  'ctrl-alt-x': 'roku-develop:switch-files'

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -254,16 +254,35 @@ module.exports        = RokuDevelop =
   #
   switch: ->
     editor = atom.workspace.getActivePaneItem()
+    panes = atom.workspace.getPanes()
     if editor
       file = editor.buffer.file
       if file
-        filename = file.path.substring(file.path.lastIndexOf("/") + 1).replace(/\.[^/.]+$/, "")
+        filename = file.path.substring(file.path.lastIndexOf("/") + 1)
+        fileplain = filename.replace(/\.[^/.]+$/, "")
+        console.debug filename + " -> " + fileplain
         folderpath = file.path.substring(0, file.path.lastIndexOf("/"))
         fs.readdir folderpath, {}, (err, files) =>
-          files.forEach (file) =>
-            if file.indexOf "." > -1
-              atom.workspace.open(folderpath + "/" + file)
-
+          files.forEach (xfile) =>
+            console.debug xfile
+            console.debug xfile + " matches " + filename + ": " + (xfile == filename)
+            if xfile != filename
+              if xfile.substring(0, fileplain.length) == fileplain and xfile.indexOf(".") > -1
+                xfiletype = xfile.substring(xfile.lastIndexOf(".") + 1)
+                console.debug "filetype:" + xfiletype
+                if xfiletype == "xml" or xfiletype == "brs"
+                  console.debug "filetype PASS"
+                  panes.forEach (pane) =>
+                    pane.getItems().forEach (tab) =>
+                      console.debug tab.getTitle()
+                      console.debug "tab is file:" + (tab.getTitle() == xfile)
+                      if tab.getTitle() == xfile
+                        console.debug "activating tab " + xfile
+                        pane.activateItem(tab)
+                        pane.activate()
+                        return
+                  atom.workspace.open(folderpath + "/" + xfile)
+                  return
 
   #
   # Invoked when the roku-develop:deploy command is issued

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -282,7 +282,23 @@ module.exports        = RokuDevelop =
                     switchMade = true
             return if switchMade
 
-
+  switch: ->
+    editor = atom.workspace.getActiveTextEditor()
+    editorPath = editor?.getPath()
+    if editorPath
+      editorPathParsed = path.parse(editorPath)
+      editorPathParsed.ext =
+        if editorPathParsed.ext is '.brs' then '.xml'
+        else if editorPathParsed.ext is '.xml' then '.brs'
+        else ''
+      if editorPathParsed.ext
+        editorPathParsed.base = ''  # path.format() ignores ext if base present
+        switchPath = path.format(editorPathParsed)
+        pane = atom.workspace.paneForURI(switchPath)
+        if not pane?.activateItemForURI(switchPath)
+          fileObj = new File(switchPath)
+          fileObj?.exists().then((fileExists) ->
+            atom.workspace.open(switchPath) if fileExists)
   #
   # Invoked when the roku-develop:deploy command is issued
   #

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -199,6 +199,9 @@ module.exports        = RokuDevelop =
     @subscriptions.add atom.commands.add  'atom-workspace',
                                           'roku-develop:package': => @package()
 
+    @subscriptions.add atom.commands.add  'atom-workspace',
+                                          'roku-develop:switch-files': => @switch()
+
     # Initiate device discovery
     # 'bind' ensures callback executes in the context of the main package code
     # Do not initiate SSDP discovery if automatic discovery is turned off
@@ -244,6 +247,23 @@ module.exports        = RokuDevelop =
   #
   toggle: ->
     if @panel.isVisible() then @panel.hide() else @panel.show()
+
+
+  #
+  # Invoked when the roku-develop:switch-files command is issued
+  #
+  switch: ->
+    editor = atom.workspace.getActivePaneItem()
+    if editor
+      file = editor.buffer.file
+      if file
+        filename = file.path.substring(file.path.lastIndexOf("/") + 1).replace(/\.[^/.]+$/, "")
+        folderpath = file.path.substring(0, file.path.lastIndexOf("/"))
+        fs.readdir folderpath, {}, (err, files) =>
+          files.forEach (file) =>
+            if file.indexOf "." > -1
+              atom.workspace.open(folderpath + "/" + file)
+
 
   #
   # Invoked when the roku-develop:deploy command is issued

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -258,24 +258,29 @@ module.exports        = RokuDevelop =
     if editor
       file = editor.buffer.file
       if file
+        switchMade = false
         filename = file.path.substring(file.path.lastIndexOf("/") + 1)
         fileplain = filename.replace(/\.[^/.]+$/, "")
         folderpath = file.path.substring(0, file.path.lastIndexOf("/"))
         fs.readdir folderpath, {}, (err, files) =>
-          files.forEach (xfile) =>
+          for xfile in files
             if xfile != filename
               if xfile.substring(0, fileplain.length) == fileplain and xfile.indexOf(".") > -1
                 xfiletype = xfile.substring(xfile.lastIndexOf(".") + 1)
                 if xfiletype == "xml" or xfiletype == "brs"
                   if panes
-                    panes.forEach (pane) =>
-                      pane.getItems().forEach (tab) =>
+                    for pane in panes
+                      for tab in pane.getItems()
                         if tab.getTitle() == xfile
                           pane.activateItem(tab)
                           pane.activate()
-                          return
-                  atom.workspace.open(folderpath + "/" + xfile)
-                  return
+                          switchMade = true
+                        return if switchMade
+                      return if switchMade
+                  if switchMade == false
+                    atom.workspace.open(folderpath + "/" + xfile)
+                    switchMade = true
+            return if switchMade
 
 
   #

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -260,29 +260,22 @@ module.exports        = RokuDevelop =
       if file
         filename = file.path.substring(file.path.lastIndexOf("/") + 1)
         fileplain = filename.replace(/\.[^/.]+$/, "")
-        console.debug filename + " -> " + fileplain
         folderpath = file.path.substring(0, file.path.lastIndexOf("/"))
         fs.readdir folderpath, {}, (err, files) =>
           files.forEach (xfile) =>
-            console.debug xfile
-            console.debug xfile + " matches " + filename + ": " + (xfile == filename)
             if xfile != filename
               if xfile.substring(0, fileplain.length) == fileplain and xfile.indexOf(".") > -1
                 xfiletype = xfile.substring(xfile.lastIndexOf(".") + 1)
-                console.debug "filetype:" + xfiletype
                 if xfiletype == "xml" or xfiletype == "brs"
-                  console.debug "filetype PASS"
                   panes.forEach (pane) =>
                     pane.getItems().forEach (tab) =>
-                      console.debug tab.getTitle()
-                      console.debug "tab is file:" + (tab.getTitle() == xfile)
                       if tab.getTitle() == xfile
-                        console.debug "activating tab " + xfile
                         pane.activateItem(tab)
                         pane.activate()
                         return
                   atom.workspace.open(folderpath + "/" + xfile)
                   return
+
 
   #
   # Invoked when the roku-develop:deploy command is issued

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -255,7 +255,7 @@ module.exports        = RokuDevelop =
   switch: ->
     editor = atom.workspace.getActivePaneItem()
     panes = atom.workspace.getPanes()
-    if editor
+    if editor and editor.buffer
       file = editor.buffer.file
       if file
         switchMade = false

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -253,36 +253,6 @@ module.exports        = RokuDevelop =
   # Invoked when the roku-develop:switch-files command is issued
   #
   switch: ->
-    editor = atom.workspace.getActivePaneItem()
-    panes = atom.workspace.getPanes()
-    if editor and editor.buffer
-      file = editor.buffer.file
-      if file
-        switchMade = false
-        filename = file.path.substring(file.path.lastIndexOf("/") + 1)
-        fileplain = filename.replace(/\.[^/.]+$/, "")
-        folderpath = file.path.substring(0, file.path.lastIndexOf("/"))
-        fs.readdir folderpath, {}, (err, files) =>
-          for xfile in files
-            if xfile != filename
-              if xfile.substring(0, fileplain.length) == fileplain and xfile.indexOf(".") > -1
-                xfiletype = xfile.substring(xfile.lastIndexOf(".") + 1)
-                if xfiletype == "xml" or xfiletype == "brs"
-                  if panes
-                    for pane in panes
-                      for tab in pane.getItems()
-                        if tab.getTitle() == xfile
-                          pane.activateItem(tab)
-                          pane.activate()
-                          switchMade = true
-                        return if switchMade
-                      return if switchMade
-                  if switchMade == false
-                    atom.workspace.open(folderpath + "/" + xfile)
-                    switchMade = true
-            return if switchMade
-
-  switch: ->
     editor = atom.workspace.getActiveTextEditor()
     editorPath = editor?.getPath()
     if editorPath

--- a/lib/roku-develop.coffee
+++ b/lib/roku-develop.coffee
@@ -267,12 +267,13 @@ module.exports        = RokuDevelop =
               if xfile.substring(0, fileplain.length) == fileplain and xfile.indexOf(".") > -1
                 xfiletype = xfile.substring(xfile.lastIndexOf(".") + 1)
                 if xfiletype == "xml" or xfiletype == "brs"
-                  panes.forEach (pane) =>
-                    pane.getItems().forEach (tab) =>
-                      if tab.getTitle() == xfile
-                        pane.activateItem(tab)
-                        pane.activate()
-                        return
+                  if panes
+                    panes.forEach (pane) =>
+                      pane.getItems().forEach (tab) =>
+                        if tab.getTitle() == xfile
+                          pane.activateItem(tab)
+                          pane.activate()
+                          return
                   atom.workspace.open(folderpath + "/" + xfile)
                   return
 

--- a/menus/roku-develop.cson
+++ b/menus/roku-develop.cson
@@ -14,6 +14,10 @@
         {
         label: 'Package'
         command: 'roku-develop:package'
+        },
+        {
+        label: 'Switch files'
+        command: 'roku-develop:switch-files'
         }
       ]
     }
@@ -35,6 +39,10 @@ menu: [
         {
         label: 'Package'
         command: "roku-develop:package"
+        },
+        {
+        label: 'Switch files'
+        command: 'roku-develop:switch-files'
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "atom-workspace": [
       "roku-develop:toggle",
       "roku-develop:deploy",
-      "roku-develop:package"
+      "roku-develop:package",
+      "roku-develop:switch-files"
     ]
   },
   "repository": "https://github.com/belltown/roku-develop",

--- a/spec/roku-develop-spec.coffee
+++ b/spec/roku-develop-spec.coffee
@@ -60,3 +60,7 @@ describe "RokuDevelop", ->
         expect(rokuDevelopElement).toBeVisible()
         atom.commands.dispatch workspaceElement, 'roku-develop:toggle'
         expect(rokuDevelopElement).not.toBeVisible()
+
+  describe "when the roku-develop:switch-files event is triggered", ->
+    it "opens a file with the same name", ->
+      expect(true)


### PR DESCRIPTION
hello!

this addition would simplify switching back and forth between brs and xml files for a component by creating a keyboard shortcut to do it automatically (<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd>). if a file is open elsewhere, even in another pane, it will focus on that tab/pane; if it's not open yet, it will open the file in a new tab in the active pane.

a similar feature is included in brightscript/rsg plugins for other editors ([vscode](https://github.com/TwitchBronBron/vscode-brightscript-language/blob/master/CHANGELOG.md#added-5), [eclipse](https://github.com/georgejecook/rokuComfortEclipsePlugin)...).